### PR TITLE
Allow pod annotations to be added to pods via values.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/iofog/templates/connector.yml
+++ b/iofog/templates/connector.yml
@@ -14,6 +14,12 @@ spec:
     metadata:
       labels:
         name: connector
+      {{- if .Values.connector.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.connector.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
       initContainers:
         - name: wait-for-controller

--- a/iofog/templates/controller.yml
+++ b/iofog/templates/controller.yml
@@ -43,6 +43,12 @@ spec:
     metadata:
       labels:
         name: controller
+      {{- if .Values.controller.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: svacc-iofog-controller
       volumes:

--- a/iofog/templates/kubelet.yml
+++ b/iofog/templates/kubelet.yml
@@ -41,9 +41,9 @@ spec:
     metadata:
       labels:
         name: kubelet
-      {{- if .Values.connector.podAnnotations }}
+      {{- if .Values.kubelet.podAnnotations }}
       annotations:
-      {{- range $key, $value := .Values.connector.podAnnotations }}
+      {{- range $key, $value := .Values.kubelet.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- end }}

--- a/iofog/templates/kubelet.yml
+++ b/iofog/templates/kubelet.yml
@@ -41,6 +41,12 @@ spec:
     metadata:
       labels:
         name: kubelet
+      {{- if .Values.connector.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.connector.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: svacc-iofog-kubelet
       volumes:

--- a/iofog/templates/operator.yml
+++ b/iofog/templates/operator.yml
@@ -79,9 +79,9 @@ spec:
     metadata:
       labels:
         name: operator
-      {{- if .Values.controller.podAnnotations }}
+      {{- if .Values.operator.podAnnotations }}
       annotations:
-      {{- range $key, $value := .Values.controller.podAnnotations }}
+      {{- range $key, $value := .Values.operator.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- end }}

--- a/iofog/templates/operator.yml
+++ b/iofog/templates/operator.yml
@@ -79,6 +79,12 @@ spec:
     metadata:
       labels:
         name: operator
+      {{- if .Values.controller.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: operator
       containers:

--- a/iofog/templates/setup.yml
+++ b/iofog/templates/setup.yml
@@ -5,6 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace | default .Values.defaultNamespace }}
 spec:
   template:
+    metadata:
+      {{- if .Values.controller.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
       initContainers:
       - name: wait-for-controller

--- a/iofog/values.yaml
+++ b/iofog/values.yaml
@@ -1,6 +1,6 @@
 defaultNamespace: "iofog"
 
-createCustomResource: true
+createCustomResource: false
 
 controller:
   replicas: 1
@@ -9,18 +9,24 @@ controller:
   host: controller
   port: 51121
   loadBalancerIP: ""
+  podAnnotations:
+    sidecar.istio.io/inject: "false"
 
 connector:
   replicas: 1
   image: "iofog/connector:1.2.0"
   imagePullPolicy: Always
   port: 8080
+  podAnnotations:
+    sidecar.istio.io/inject: "false"
 
 operator:
   replicas: 1
   image: "iofog/iofog-operator:1.2.0"
   imagePullPolicy: Always
   port: 60000
+  podAnnotations:
+    sidecar.istio.io/inject: "false"
 
 kubelet:
   replicas: 1
@@ -28,6 +34,8 @@ kubelet:
   imagePullPolicy: Always
   apiServerHost: kubernetes.default.svc
   apiServerPort: 443
+  podAnnotations:
+    sidecar.istio.io/inject: "false"
 
 tests:
   image: "iofog/test-runner:1.2.0"

--- a/iofog/values.yaml
+++ b/iofog/values.yaml
@@ -1,6 +1,6 @@
 defaultNamespace: "iofog"
 
-createCustomResource: false
+createCustomResource: true
 
 controller:
   replicas: 1


### PR DESCRIPTION
Not sure if this approach is what you guys will want to go with, but it works to allow annotations to be injected into all of the components. Note that the `setup` container uses the annotations for `controller` since there wasn't an existing section in `values.yaml` for it.